### PR TITLE
feat: suport InCluster configuration (in fission-cli)

### DIFF
--- a/pkg/fission-cli/cmd/client.go
+++ b/pkg/fission-cli/cmd/client.go
@@ -134,12 +134,14 @@ func GetClientConfig(kubeContext string) (clientcmd.ClientConfig, error) {
 		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides), nil
 	}
 
-	console.Warn("Could not load kubeconfig, falling back to in-cluster config")
+	console.Verbose(2, "Could not load kubeconfig, falling back to in-cluster config")
 
 	inClusterConfig, err := InClusterConfig()
 	if err != nil {
 		return nil, err
 	}
+
+	console.Verbose(2, "InClusterConfig correct")
 
 	apiConfig := &api.Config{
 		Clusters: map[string]*api.Cluster{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The `GetClientConfig` function (from fission-cli) was modified to support configuration credentials from a Kubernetes cluster (`InClusterConfig` function).

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
